### PR TITLE
Relative humidity sensor

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -6,7 +6,9 @@
     {
       "accessory": "SpeedtestNet",
       "name": "Internet",
-      "interval": 60
+      "interval": 60,
+      "maxdlspeed": 600,
+      "maxulspeed": 20
     }
 ],
  "platforms": [


### PR DESCRIPTION
This code is intended to address temperature units issue (Celsius vs Fahrenheit) in Home App by using a relative humidity sensor.  This code also expands the function to show alerts for bad upload or ping times.

- Relative humidity is percent of max download speed
- Sensor also has battery and fault triggers for upload speeds < 50% and  ping times > 20ms

Following image shows healthy network (but with only 47% of max download speed - maybe I need to bug my ISP LoL):

<img width="129" alt="Screen Shot 2020-04-30 at 11 57 10 PM" src="https://user-images.githubusercontent.com/64129452/80788568-5051e900-8b3e-11ea-88eb-ffee6a72e996.png">

This image shows an unhealthy network (0% download, 0% upload, and > 20ms ping):

<img width="120" alt="Screen Shot 2020-05-01 at 12 04 17 AM" src="https://user-images.githubusercontent.com/64129452/80788913-4e3c5a00-8b3f-11ea-8e2d-578787462ef5.png">
