### PR TITLE
Added fix for Fahrenheit + Debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ This problems occures because the NodeJS tool [speedtest.net](https://github.com
     {
       "accessory": "SpeedtestNet",
       "name": "Internet",
-      "interval": 60
+      "interval": 60,
+      "fahrenheit": true,
+      "debug": false
     }
   ]
 }
@@ -62,7 +64,9 @@ This problems occures because the NodeJS tool [speedtest.net](https://github.com
 |------------|----------|-------|
 | accessory | **Yes** | Must be "SpeedtestNet" |
 | name | No | Name for the Accessory (Default: SpeedtestNet) |
-| interval | No | Interval for checing the broadband in mins (Default: 60min) |
+| interval | No | Interval for checking the broadband in mins (Default: 60min) |
+| fahrenheit | No | Use this if your temperature scale is fahrenheit in HomeKit (Default: false) |
+| debug | No | This adds additional logging of SpeedTest data (Default: false) |
 
 
 ## Contributing

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,9 +1,10 @@
 {
 	"pluginAlias": "SpeedtestNet",
 	"pluginType": "accessory",
+  "singular": true,
 	"schema": {
-   "type": "object",
-   "properties": {
+		"type": "object",
+		"properties": {
 			"name": {
 				"title": "Name",
 				"type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,33 @@
+{
+	"pluginAlias": "SpeedtestNet",
+	"pluginType": "accessory",
+	"schema": {
+   "type": "object",
+   "properties": {
+			"name": {
+				"title": "Name",
+				"type": "string",
+				"default": "Internet",
+				"required": true
+			},
+			"interval": {
+				"title": "Interval",
+				"type": "number",
+				"default": 60,
+				"description": "Interval for checking the broadband in mins."
+			},
+			"fahrenheit": {
+				"title": "Fahrenheit",
+				"type": "boolean",
+				"default": false,
+				"description": "Use this if your temperature scale is fahrenheit in HomeKit."
+			},
+			"debug": {
+				"title": "Debug",
+				"type": "boolean",
+				"default": false,
+				"description": "Enables additional logging of SpeedTest data."
+			}
+		}
+	}
+}

--- a/example-config.json
+++ b/example-config.json
@@ -6,7 +6,9 @@
     {
       "accessory": "SpeedtestNet",
       "name": "Internet",
-      "interval": 60
+      "interval": 60,
+      "fahrenheit": true,
+      "debug": false
     }
 ],
  "platforms": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-speedtest-net",
   "description": "Homebridge plugin for Speedtest.net",
-  "displayName": "Homebridge Speedtest.net",
+  "displayName": "SpeedtestNet",
   "author": "Stefan Kienzle",
   "license": "MIT",
   "version": "1.1.4",


### PR DESCRIPTION
I use Fahrenheit in my homekit.  This plugin did not display correctly.  I added a config variable and logic to adjust for the use of Fahrenheit, as well as a debug setting to display the response from the call to SpeedTest.

Lastly, I created a config.schema.json for the plugin.